### PR TITLE
Fixed README error in installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dependencies {
 }
 ```
 
-Or add EasyFlipView as a new dependency inside your pom.xml
+Or add RoomExplorer as a new dependency inside your pom.xml
 
 ```xml
 <dependency> 


### PR DESCRIPTION
You were using your other project's name for installation instruction, corrected it.